### PR TITLE
live: Remove broadcom drivers from seed

### DIFF
--- a/live
+++ b/live
@@ -52,7 +52,6 @@ These packages make up the Ubiquity live installer.
 
 == Misc ==
 
- * bcmwl-kernel-source
  * gparted
  * cifs-utils # Needed by casper for CIFS root=
  * jfsutils # Needed for JFS installation (lp:1442982)


### PR DESCRIPTION
This removes `bcmwl-kernel-source` from the list of packages installed by the `elementary-live` metapackage.

The `elementary-live` metapackage is used for extra packages needed in the live session that are to be removed by Ubiquity during the install.

Having this in the list of packages means that the Broadcom WiFi driver is pre-installed on a live image, so WiFi works out of the box on broadcom cards when booting from the live USB. As it's a proprietary driver, Ubiquity will only install it if you tick the proprietary drivers box. But the fact that it's already installed messes with the logic and you end up without it in the installed system even if you've ticked the box. This leaves you scrambling for some way to get online to install the driver with laptops that increasingly don't have ethernet ports.

I've tested this in my .iso builds by not installing the `elementary-live` metapackage and just manually listing the same set of packages without this in the list.

What happens without this in the live packages is that no WiFi is detected on the live boot, until you check the proprietary drivers box and press next. At that point, the driver is installed and you can connect to a WiFi network before continuing the install if you wish. The driver also persists on the installed system if you go ahead and complete the install.