### PR TITLE
live: Explicitly list more live session deps

### DIFF
--- a/live
+++ b/live
@@ -58,3 +58,8 @@ These packages make up the Ubiquity live installer.
  * jfsutils # Needed for JFS installation (lp:1442982)
  * xfsprogs # Needed for XFS installation
 
+ * casper
+ * discover
+ * laptop-detect
+ * os-prober
+


### PR DESCRIPTION
I think these would get pulled in as dependencies anyway, but it's better to be explicit in case that changes any reason. These are all needed for either auto detecting hardware or auto configuring users/login/etc... during the live session. As they are in the `live` list, they will be removed again in the installed system.