### PR TITLE
checkout seeds in pipeline actions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,11 +12,15 @@ jobs:
       image: debian:stable-slim
 
     steps:
+    - name: Checkout seeds
+      uses: actions/checkout@v2
+
     - name: Checkout metapackages
       uses: actions/checkout@v2
       with:
         repository: elementary/metapackages
         path: metapackages
         token: "${{ secrets.GIT_USER_TOKEN }}"
+
     - name: Update metapackages
       run: cd metapackages && bash ../update_metapackages.sh focal


### PR DESCRIPTION

__CHANGES:__

* To make `update_metadata.sh` available to run in the pipelines, the action now checks out the `seeds` repo as well.

Resolves the error found here: 
https://github.com/elementary/seeds/commit/48105efe77e704ecc96ab9ff3c54fea8a6c4cb47/checks?check_suite_id=400519645