### PR TITLE
Blacklist gdm3 in focal

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -79,6 +79,7 @@ fonts-liberation
 fonts-lklug-sinhala
 fonts-thai-tlwg
 fonts-tibetan-machine
+gdm3
 gnome-control-center
 gnome-screensaver
 # we only want gnome-session-bin not configs


### PR DESCRIPTION
GDM3 is being installed and overriding LightDM, hence why we're getting a stock GNOME session in the focal iso