### PR TITLE
Use ubuntu image

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: debian:stable-slim
+      image: ubuntu:latest
 
     steps:
     # We need git to checkout the metapackages repository with git so keep it above


### PR DESCRIPTION
__CHANGES:__

* use `ubuntu:latest` instead of `debian:stable-slim` since the version of debootstrap in the debian containers doesn't have the `focal` script yet.