### PR TITLE
Use latest ubuntu release for update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:latest
+      image: ubuntu:rolling
 
     steps:
     # We need git to checkout the metapackages repository with git so keep it above


### PR DESCRIPTION
`rolling` points to the latest released version, currently 19.10.

From the checkout action documentation:
> When Git 2.18 or higher is not in your PATH, falls back to the REST API to download the files.

Current `latest` (AKA LTS), provides Git 2.17 and hence the action just downloads the tarball instead of cloning the repo, so we can't diff it or push the changes back.

If we use a newer version of Ubuntu, we'll get newer git.