### PR TITLE
Focal: add distinst

### DIFF
--- a/live
+++ b/live
@@ -42,9 +42,15 @@ default live.
  * fonts-arphic-uming
  * fonts-arphic-ukai
 
+== Distinst components ==
+
+ * distinst
+ * io.elementary.installer
+
 == Misc ==
 
  * gparted
+ * expect
  * cifs-utils # Needed by casper for CIFS root=
  * jfsutils # Needed for JFS installation (lp:1442982)
  * xfsprogs # Needed for XFS installation


### PR DESCRIPTION
Add distinst packages to `elementary-live`. The list of packages was pulled from here:

[etc/config/package-lists.distinst/desktop.list.chroot_live](https://github.com/elementary/os/blob/c3018e04127104d483bcbe17cd212964968a4b15/etc/config/package-lists.distinst/desktop.list.chroot_live)

I'm not 100% sure we need expect, but I've left it in here since it was there before, and I haven't tested things without the expect package.