### PR TITLE
Update geoclue package name

### DIFF
--- a/desktop
+++ b/desktop
@@ -98,16 +98,7 @@ Wingpanel and indicators:
  * (wingpanel-indicator-sound)
 
 Location Support:
- * (geoclue-localnet)
-# * (geoclue-plazes) # crashes every day
- * (geoclue-yahoo)
- * (geoclue-ubuntu-geoip)
- * (geoclue-skyhook)
-GSM:
- * (geoclue-gsmloc)
-Street Names:
- * (geoclue-nominatim)
- * (geoclue-geonames)
+ * (geoclue-2.0)
 
 OS-only stuff:
  * (capnet-assist)


### PR DESCRIPTION
Seems all the `geoclue-x` stuff is gone in `focal` now and we just have `geoclue-2.0`