### PR TITLE
Reflect recent GitHub actions bugfixes from focal

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: debian:stable-slim
+      image: ubuntu:rolling
 
     steps:
     # We need git to checkout the metapackages repository with git so keep it above
@@ -41,6 +41,8 @@ jobs:
             echo "Everything is up-to-date, nothing to commit"
         else
             echo "Committing new changes"
+            git config --global user.email "builds@elementary.io"
+            git config --global user.name "elementaryBot"
             git add .
             git commit -m "Automatic update via elementary seeds"
             git push origin "$BRANCH"


### PR DESCRIPTION
`ubuntu:rolling` has a new enough version of git that allows the `actions/checkout@v2` action to work properly and has the necessary debootstrap scripts for newer distributions.

git username and email need setting or else the push fails.