### PR TITLE
focal: blacklist ubuntu-session

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -111,6 +111,7 @@ ubuntu-artwork
 ubuntu-desktop
 ubuntu-release-upgrader-core
 ubuntu-release-upgrader-gtk
+ubuntu-session
 ubuntu-system-settings
 ubuntu-touch-sounds
 # unar pulls in gnustep-base resulting in gdomap running, lp:1357051


### PR DESCRIPTION
This was overriding pantheon as the default session, it seems it's pulled in by `gnome-session` which is also in this blacklist file, so maybe we need to blacklist both to make them go away.