### PR TITLE
prevent apt from getting stuck when installing tzdata

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,7 +17,7 @@ jobs:
       shell: bash
       run: |
         apt-get update
-        apt-get install -y git devscripts debootstrap germinate
+        apt-get install -qq tzdata git devscripts debootstrap germinate
 
     - name: Checkout seeds
       uses: actions/checkout@v2

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -16,8 +16,9 @@ jobs:
     - name: Install dependencies
       shell: bash
       run: |
-        apt-get update
-        apt-get install -qq tzdata git devscripts debootstrap germinate
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get -qq update
+        apt-get -qq install tzdata git devscripts debootstrap germinate
 
     - name: Checkout seeds
       uses: actions/checkout@v2


### PR DESCRIPTION
same fix as https://github.com/elementary/actions/pull/34, this installs tzdata to prevent `apt-get install` from hanging indefinitely