### PR TITLE
Pantheon: Remove epiphany-browser

### DIFF
--- a/pantheon
+++ b/pantheon
@@ -7,7 +7,6 @@ Task-Metapackage: pantheon
 
 # apps shipped by default, in alphabetical order:
  * (appcenter)
- * (epiphany-browser)
  * (maya-calendar)
  * (noise)
  * (pantheon-files)


### PR DESCRIPTION
Since we're now shipping it as Flatpak