### PR TITLE
Desktop: Remove lastfm from recommends

### DIFF
--- a/desktop
+++ b/desktop
@@ -117,7 +117,6 @@ Pantheon Online Accounts:
  * (evolution-data-server-pantheon-online-accounts)
  * (gsignond)
  * (gsignond-plugin-oauth)
- * (gsignond-plugin-lastfm)
 
 Prerelease stuff:
  * (elementary-os-prerelease)


### PR DESCRIPTION
We don't need this after the EDS-rewrite of Online Accounts