### PR TITLE
Pantheon: Add back Mail

### DIFF
--- a/pantheon
+++ b/pantheon
@@ -12,6 +12,7 @@ Task-Metapackage: pantheon
  * (pantheon-files)
  * (pantheon-photos)
  * (io.elementary.code)
+ * (io.elementary.mail)
  * (io.elementary.settings-daemon)
  * (io.elementary.shortcut-overlay)
  * (io.elementary.sideload)


### PR DESCRIPTION
It seems like online accounts can't communicate passwords to Mail, so the fastest fix is to continue shipping the deb version until we can get that sorted