### PR TITLE
Prevent installation of budgie-desktop on iso

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -65,6 +65,7 @@ apport-symptoms
 apt-transport-https
 banshee
 branding-ubuntu
+budgie-desktop
 compiz
 # creates ~/example.desktop
 example-content


### PR DESCRIPTION
This is on the latest daily iso as a result of some `Recommends` by `gnome-bluetooth`. Tested that it can be removed from the iso without consequential removal of other packages we need.