### PR TITLE
jammy: Remove gnome-remote-desktop

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -82,6 +82,7 @@ fonts-thai-tlwg
 fonts-tibetan-machine
 gdm3
 gnome-control-center
+gnome-remote-desktop
 gnome-screensaver
 # we only want gnome-session-bin not configs
 gnome-session


### PR DESCRIPTION
Pulls in `budgie-desktop` as a hard dependency if `gnome-shell` is not installed.