### PR TITLE
sdk: Add Granite 7

### DIFF
--- a/elementary-sdk
+++ b/elementary-sdk
@@ -16,6 +16,7 @@ Task-Metapackage: elementary-sdk
  * (git)
  * gobject-introspection
  * (granite-demo)
+ * (granite-7-demo)
  * (gtk-3-examples) # gtk3-icon-browser
  * (gtk-4-examples) # widget factory, demo
  * (io.elementary.code) # official elementary IDE
@@ -25,6 +26,7 @@ Task-Metapackage: elementary-sdk
  * libgirepository1.0-dev
  * libglib2.0-dev
  * libgranite-dev # elementary development library
+ * libgranite-7-dev
  * libgtk-3-dev
  * libgtk-4-dev
  * libhandy-1-dev


### PR DESCRIPTION
Means that the SDK metapackage will pull in the GTK4 version of Granite.