### PR TITLE
Desktop: remove geoclue agent

### DIFF
--- a/desktop
+++ b/desktop
@@ -107,7 +107,6 @@ OS-only stuff:
  * (capnet-assist)
  * (elementary-default-settings)
  * (gnome-session-bin)       # starts up cerbere according to default-settings
- * (pantheon-agent-geoclue2)
  * (pantheon-agent-polkit)
  * (p7zip-full)            # elementary: supports a crazy number of formats
 


### PR DESCRIPTION
Goes hand in hand with https://github.com/elementary/switchboard-plug-security-privacy/pull/148 and https://github.com/elementary/default-settings/pull/279

The agent doesn't work with newer version of GeoClue, but the portal does work, so this is part of switching over