### PR TITLE
Desktop: remove im-config

### DIFF
--- a/desktop
+++ b/desktop
@@ -33,7 +33,6 @@ Input methods:
 
  * (gtk-im-libthai)
  * (ibus-chewing)
- * (im-config)
  * (ibus)
  * (ibus-gtk)
  * (ibus-gtk3)


### PR DESCRIPTION
Fixes https://github.com/elementary/switchboard-plug-keyboard/issues/439
Not complete but still a fix for https://github.com/elementary/wingpanel-indicator-keyboard/issues/108

im-config provides an autostart file for ibus-daemon (the cause of https://github.com/elementary/switchboard-plug-keyboard/issues/439), which on first launch sets redundant engines in `org.freedesktop.ibus.general preload-engines` and then the switchboard plug syncs them to the `org.gnome.desktop.input-sources sources` which results in https://github.com/elementary/wingpanel-indicator-keyboard/issues/108.

Autostart file for ibus is already being created by the switchboard plug and the user can disable/enable it through Applications -> Startup.

I'm not sure if it does anything besides that, so I'd like to get review from @ryonakano since he probably knows about this more than me.