### PR TITLE
Sdk: Drop libplank

### DIFF
--- a/elementary-sdk
+++ b/elementary-sdk
@@ -30,7 +30,6 @@ Task-Metapackage: elementary-sdk
  * libgtk-3-dev
  * libgtk-4-dev
  * libhandy-1-dev
- * libplank-dev
  * libswitchboard-2.0-dev
  * libunity-dev
  * libwingpanel-dev


### PR DESCRIPTION
We have had Granite methods for badges etc for a while now