### PR TITLE
Desktop: add settings.useraccounts

### DIFF
--- a/desktop
+++ b/desktop
@@ -73,12 +73,11 @@ System Settings and extensions:
  * (io.elementary.settings.sharing)
  * (io.elementary.settings.sound)
  * (io.elementary.settings.system)
+ * (io.elementary.settings.useraccounts)
 
 Switchboard and plugs:
  * (io.elementary.switchboard.wacom)
  * (switchboard)
- * (switchboard-plug-about)
- * (switchboard-plug-a11y)
  * (switchboard-plug-display)
  * (switchboard-plug-keyboard)
  * (switchboard-plug-networking)
@@ -86,7 +85,6 @@ Switchboard and plugs:
  * (switchboard-plug-parental-controls)
  * (switchboard-plug-printers)
  * (switchboard-plug-security-privacy)
- * (switchboard-plug-useraccounts)
 
 UI and branding fonts for elementary:
  * (fonts-elementary-core)


### PR DESCRIPTION
Add freshly packages UserAccounts

* Drop switchboard-plug-useraccounts which this replaces
* Drop switchboard-plug-about which was already replaced by io.elementary.settings.system
* Drop switchboard-plug-a11y which is now unnecessary