### PR TITLE
Desktop: wingpanel-session → quick-settings

### DIFF
--- a/desktop
+++ b/desktop
@@ -89,6 +89,7 @@ UI and branding fonts for elementary:
  * (fonts-elementary-core)
 
 Wingpanel and indicators:
+ * (io.elementary.quick-settings)
  * (io.elementary.wingpanel)
  * (wingpanel-indicator-a11y)
  * (wingpanel-indicator-bluetooth)
@@ -98,7 +99,6 @@ Wingpanel and indicators:
  * (wingpanel-indicator-nightlight)
  * (wingpanel-indicator-notifications)
  * (wingpanel-indicator-power)
- * (wingpanel-indicator-session)
  * (wingpanel-indicator-sound)
 
 Location Support:

--- a/desktop
+++ b/desktop
@@ -91,7 +91,6 @@ UI and branding fonts for elementary:
 Wingpanel and indicators:
  * (io.elementary.quick-settings)
  * (io.elementary.wingpanel)
- * (wingpanel-indicator-a11y)
  * (wingpanel-indicator-bluetooth)
  * (wingpanel-indicator-datetime)
  * (wingpanel-indicator-keyboard)


### PR DESCRIPTION
![Screenshot from 2024-02-12 16 34 25](https://github.com/elementary/seeds/assets/7277719/0665e418-73bd-4259-bb8a-ca1b00d155ab)

I want to start a more serious discussion about shipping a quick settings indicator a la https://github.com/elementary/wingpanel/discussions/446

So far https://github.com/elementary/quick-settings has features that don't currently fit in other indicators like dark mode and rotation lock with proposals for things like Power Saver and it completely takes over a11y settings:

![Screenshot from 2024-02-12 16 37 38](https://github.com/elementary/seeds/assets/7277719/fda3479d-7d95-48e4-a25f-fdd488aa003d)
