### PR TITLE
Desktop: replace gnome-bluetooth with elementary bluetooth daemon

### DIFF
--- a/desktop
+++ b/desktop
@@ -11,8 +11,7 @@ Task-Seeds: desktop-common
 
 Bluetooth:
 
- * (gnome-bluetooth) # desktop bluetooth support
- * (io.elementary.contractor.gnome-bluetooth-contract)
+ * (io.elementary.bluetooth-daemon) # bluetooth sharing support
 
 = Network Services =
 


### PR DESCRIPTION
We're definitely not building that contract package currently and I think gnome-bluetooth is only related to that bluetooth sharing functionality that we have the bluetooth daemon for

Bluetooth daemon is pulled in by sharing settings, but should pull it in explicitly anyways