### PR TITLE
Desktop: settings-bluetooth → settings.bluetooth

### DIFF
--- a/desktop
+++ b/desktop
@@ -63,7 +63,7 @@ System-wide distro-specific artwork:
 System Settings and extensions:
  * (io.elementary.settings)
  * (io.elementary.settings.applications)
- * (io.elementary.settings-bluetooth)
+ * (io.elementary.settings.bluetooth)
  * (io.elementary.settings.datetime)
  * (io.elementary.settings.desktop)
  * (io.elementary.settings.display)


### PR DESCRIPTION
Goes with https://github.com/elementary/switchboard-plug-bluetooth/pull/225