### PR TITLE
Ship: remove OEM packages

### DIFF
--- a/ship
+++ b/ship
@@ -44,8 +44,6 @@
 == Installer ==
 
  * bootstrap-base
- * oem-config-gtk
- * oem-config-slideshow-ubuntu
  * uboot-mkimage [armel]
  * partman-iscsi
 


### PR DESCRIPTION
I think we don't need this since we use our own installer these days yeah?