### PR TITLE
Desktop: Add udev rules for Steam devices

### DIFF
--- a/desktop
+++ b/desktop
@@ -300,6 +300,7 @@ Vietnamese:
  * (heif-gdk-pixbuf) # provides a gdk-pixbuf loader for HEIF images
  * (heif-thumbnailer) # image thumbnailer plugin for HEIF images
  * (systemd-coredump) # allows us to give consistent commands to get useful backtraces from a crash
+ * (steam-devices) # udev rules for Steam
 
 == Architecture-dependent ==
 


### PR DESCRIPTION
Fixes https://github.com/orgs/elementary/discussions/866

This only adds 20KB

It sounds like there isn't a mechanism for Steam to interface with udev in Flatpak at the moment and it's unclear what the roadmap is upstream.

I'm hearing that to complete Steam support we also need to pull in `steam-libs` but this adds a bunch of other packages like `curl` and `zenity` and `fonts-liberation`.

I wonder if we can get away with just manually including `libasound2-plugins` and  `libva-glx2` if that would solve the performance issues cited