### PR TITLE
Pantheon: remove io.elementary.print

### DIFF
--- a/pantheon
+++ b/pantheon
@@ -33,4 +33,3 @@ Task-Metapackage: pantheon
 
 # contractor and very, very default contracts
  * (contractor)
- * (io.elementary.print)


### PR DESCRIPTION
the print repo was archived. This was replaced by the printer portal: https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Print.html