### PR TITLE
desktop: Drop im-config

### DIFF
--- a/desktop
+++ b/desktop
@@ -32,7 +32,6 @@ Input methods:
 
  * (gtk-im-libthai)
  * (ibus-chewing)
- * (im-config)
  * (ibus)
  * (ibus-gtk)
  * (ibus-gtk3)


### PR DESCRIPTION
Followup https://github.com/elementary/gala/pull/2793

This package sets `GTK_IM_MODULE=ibus` which causes inappropriate position of the IBus candidate window on Wayland.

No packages depend on this so we can safely remove it.

See also:
https://github.com/elementary/gala/pull/2793#issuecomment-4147810246
