### PR TITLE
elementary-sdk: Add Granite 9

### DIFF
--- a/elementary-sdk
+++ b/elementary-sdk
@@ -17,6 +17,7 @@ Task-Metapackage: elementary-sdk
  * gobject-introspection
  * (granite-demo)
  * (granite-7-demo)
+ * (granite-9-demo)
  * (gtk-3-examples) # gtk3-icon-browser
  * (gtk-4-examples) # widget factory, demo
  * (io.elementary.code) # official elementary IDE
@@ -27,6 +28,7 @@ Task-Metapackage: elementary-sdk
  * libglib2.0-dev
  * libgranite-dev # elementary development library
  * libgranite-7-dev
+ * libgranite-9-dev
  * libgtk-3-dev
  * libgtk-4-dev
  * libhandy-1-dev


### PR DESCRIPTION
Granite 9 is already available for Resolute: https://code.launchpad.net/~elementary-os/+recipe/granite-9-daily
