### PR TITLE
Revert "elementary-sdk: Add Granite 9"

### DIFF
--- a/elementary-sdk
+++ b/elementary-sdk
@@ -17,7 +17,6 @@ Task-Metapackage: elementary-sdk
  * gobject-introspection
  * (granite-demo)
  * (granite-7-demo)
- * (granite-9-demo)
  * (gtk-3-examples) # gtk3-icon-browser
  * (gtk-4-examples) # widget factory, demo
  * (io.elementary.code) # official elementary IDE
@@ -28,7 +27,6 @@ Task-Metapackage: elementary-sdk
  * libglib2.0-dev
  * libgranite-dev # elementary development library
  * libgranite-7-dev
- * libgranite-9-dev
  * libgtk-3-dev
  * libgtk-4-dev
  * libhandy-1-dev


### PR DESCRIPTION
Reverts elementary/seeds#154

Because this seems to remove many components from amd64 metapackages for some reason: https://github.com/elementary/metapackages/commit/0c9a00f0d82ad51c54a8eb5bc22845badfd52bbc