### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
We're still using older version of `actions/checkout` in this repository:

https://github.com/elementary/seeds/blob/804220ebcd635b6c53c6c7578d91af25868cd33f/.github/workflows/update.yml#L24-L33

That version of `actions/checkout` seems to use Node.js 20, which has been EOL at the end of this April.

<img width="1021" height="283" alt="スクリーンショット 2026-05-09 14 13 15" src="https://github.com/user-attachments/assets/8d2051cb-8857-4fdd-8727-770381c1e214" />

So, let's make Dependabot create PRs to update these actions automatically.
